### PR TITLE
Update to Github Container registry and add nightly option.

### DIFF
--- a/tautulli.xml
+++ b/tautulli.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>tautulli</Name>
-  <Repository>tautulli/tautulli</Repository>
-  <Registry>https://registry.hub.docker.com/u/tautulli/tautulli/</Registry>
+  <Repository>ghcr.io/tautulli/tautulli</Repository>
+  <Registry>https://github.com/tautulli/tautulli/pkgs/container/tautulli</Registry>
   <Branch>
     <Tag>latest</Tag>
     <TagDescription>Latest stable release of Tautulli.</TagDescription>

--- a/tautulli.xml
+++ b/tautulli.xml
@@ -11,6 +11,10 @@
     <Tag>beta</Tag>
     <TagDescription>Latest beta release of Tautulli. Use with caution!</TagDescription>
   </Branch>
+  <Branch>
+    <Tag>nightly</Tag>
+    <TagDescription>The bleeding edge of Tatulli development. Use with caution!</TagDescription>
+  </Branch>
   <Network>bridge</Network>
   <Privileged>false</Privileged>
   <Support>https://tautulli.com/#support</Support>


### PR DESCRIPTION
Switches over to the GitHub Container registry since Docker will be deleting free organizations.

Also adds a nightly option as more users use the nightly branch than the beta branch.